### PR TITLE
Hauling stuff from ioq3/main.

### DIFF
--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -3733,7 +3733,7 @@ void BotMapScripts(bot_state_t *bs) {
 							shootbutton = qfalse;
 							break;
 						}
-						else if (bs->enemy == i) {
+						else if (gametype < GT_CTF || bs->enemy == i) {
 							shootbutton = qtrue;
 						}
 					}

--- a/code/renderergl1/tr_model_iqm.c
+++ b/code/renderergl1/tr_model_iqm.c
@@ -1346,7 +1346,7 @@ void RB_IQMSurfaceAnim( surfaceType_t *surface ) {
 				vtxMat[10] = blendWeights[0] * poseMats[12 * data->influenceBlendIndexes[4*influence + 0] + 10];
 				vtxMat[11] = blendWeights[0] * poseMats[12 * data->influenceBlendIndexes[4*influence + 0] + 11];
 
-				for( j = 1; j < 3; j++ ) {
+				for( j = 1; j < 4; j++ ) {
 					if ( blendWeights[j] <= 0.0f ) {
 						break;
 					}

--- a/code/renderergl2/tr_model_iqm.c
+++ b/code/renderergl2/tr_model_iqm.c
@@ -1528,7 +1528,7 @@ void RB_IQMSurfaceAnim( surfaceType_t *surface ) {
 				vtxMat[10] = blendWeights[0] * poseMats[12 * data->influenceBlendIndexes[4*influence + 0] + 10];
 				vtxMat[11] = blendWeights[0] * poseMats[12 * data->influenceBlendIndexes[4*influence + 0] + 11];
 
-				for( j = 1; j < 3; j++ ) {
+				for( j = 1; j < 4; j++ ) {
 					if ( blendWeights[j] <= 0.0f ) {
 						break;
 					}

--- a/code/sdl/sdl_snd.c
+++ b/code/sdl/sdl_snd.c
@@ -281,12 +281,7 @@ qboolean SNDDMA_Init(void)
 #ifdef USE_SDL_AUDIO_CAPTURE
 	// !!! FIXME: some of these SDL_OpenAudioDevice() values should be cvars.
 	s_sdlCapture = Cvar_Get( "s_sdlCapture", "1", CVAR_ARCHIVE | CVAR_LATCH );
-	// !!! FIXME: pulseaudio capture records audio the entire time the program is running. https://bugzilla.libsdl.org/show_bug.cgi?id=4087
-	if (Q_stricmp(SDL_GetCurrentAudioDriver(), "pulseaudio") == 0)
-	{
-		Com_Printf("SDL audio capture support disabled for pulseaudio (https://bugzilla.libsdl.org/show_bug.cgi?id=4087)\n");
-	}
-	else if (!s_sdlCapture->integer)
+	if (!s_sdlCapture->integer)
 	{
 		Com_Printf("SDL audio capture support disabled by user ('+set s_sdlCapture 1' to enable)\n");
 	}


### PR DESCRIPTION
This includes the following commits from [ioq3/main](https://github.com/ioquake/ioq3/tree/main):

-  [Fix the number of weights in the IQM model calculation](https://github.com/ioquake/ioq3/commit/4003a5b78c217588ab2cb23243e693f35d90aba0)
- [Restore bots crushing unseen player on q3tourney6 in non-CTF](https://github.com/ioquake/ioq3/commit/359db19619417117d5cd5cb8fada93e694198767) **-Not Really Needed-**
- [Allow using pulseaudio for SDL audio capture](https://github.com/ioquake/ioq3/commit/eacb83a2443ee5a7fe6f597095ce94a31fe023c2)